### PR TITLE
Change fzaninotto/faker to fakerphp/faker since the former is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3 || ^8.0",
-        "fakerphp/faker": "^1.10",
+        "fakerphp/faker": "^1.9.1",
         "pestphp/pest": "^0.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3 || ^8.0",
-        "fzaninotto/faker": "^1.9.1",
+        "fakerphp/faker": "^1.10",
         "pestphp/pest": "^0.3"
     },
     "autoload": {


### PR DESCRIPTION
Hey,
Backstory: https://twitter.com/taylorotwell/status/1321091021342650377
Can this be changed now? Or there are other steps to take before this can be done?