### PR TITLE
Fix Fatal error: Cannot redeclare Pest\Faker\faker()

### DIFF
--- a/src/Faker.php
+++ b/src/Faker.php
@@ -7,8 +7,10 @@ namespace Pest\Faker;
 use Faker\Factory;
 use Faker\Generator;
 
-/** @phpstan-ignore-next-line */
-function faker(string $locale = null): Generator
-{
-    return Factory::create($locale ?? Factory::DEFAULT_LOCALE);
+if (!function_exists('Pest\Faker\faker')) {
+    /** @phpstan-ignore-next-line */
+    function faker(string $locale = null): Generator
+    {
+        return Factory::create($locale ?? Factory::DEFAULT_LOCALE);
+    }
 }


### PR DESCRIPTION
When I use `rector/rector` to lint my code, it failed with:
```
Fatal error: Cannot redeclare Pest\Faker\faker() (previously declared in /Users/zing/data/code/github/pest-faker-test/vendor/pestphp/pest-plugin-faker/src/Faker.php:11) in /Users/zing/data/code/github/pest-faker-test/vendor/pestphp/pest-plugin-faker/src/faker.php on line 11
```

# Steps to Reproduce

composer.json
```json
{
    "name": "zing/pest-faker-test",
    "require-dev": {
        "rector/rector": "^0.9.5",
        "pestphp/pest-plugin-faker": "^1.0"
    }
}
```

rector.php
```php
<?php

declare(strict_types=1);

use Rector\Core\Configuration\Option;
use Rector\Set\ValueObject\SetList;
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

return static function (ContainerConfigurator $containerConfigurator): void {
    $parameters = $containerConfigurator->parameters();
    $parameters->set(
        Option::SETS,
        [
            SetList::CODE_QUALITY,
        ]
    );
};
```

test.php
```php
<?php

use function Pest\Faker\faker;

faker();
```

Run with: `vendor/bin/rector process test.php`

# Other solutions

1. Rename function `faker`
2. Rename file `Faker.php`

