### PR TITLE
Update dependencies for php8 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3 || ^8.0",
-        "fakerphp/faker": "^1.9.1",
+        "fakerphp/faker": "^1.9.2",
         "pestphp/pest": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Updated fakerphp/faker package to 1.9.2 which supports php 8.
